### PR TITLE
SyntheticDOM expects attributes to be provided as Object { name, value }

### DIFF
--- a/src/MarkdownParser.js
+++ b/src/MarkdownParser.js
@@ -604,7 +604,7 @@ function Renderer(options) {
 Renderer.prototype.code = function(childNode, lang) {
   var attributes = [];
   if (lang) {
-    attributes.push(['class', this.options.langPrefix + lang]);
+    attributes.push({name: 'class', value: this.options.langPrefix + lang});
   }
   var codeNode = new ElementNode('code', attributes, [childNode]);
   return new ElementNode('pre', [], [codeNode]);
@@ -661,23 +661,23 @@ Renderer.prototype.ins = function(childNode) {
 
 Renderer.prototype.link = function(href, title, childNode) {
   var attributes = [
-    ['href', href],
+    {name: 'href', value: href},
   ];
   if (title) {
-    attributes.push(['title', title]);
+    attributes.push({name: 'title', value: title});
   }
   return new ElementNode('a', attributes, [childNode]);
 };
 
 Renderer.prototype.image = function(href, title, alt) {
   var attributes = [
-    ['src', href],
+    {name: 'src', value: href},
   ];
   if (title) {
-    attributes.push(['title', title]);
+    attributes.push({name: 'title', value: title});
   }
   if (alt) {
-    attributes.push(['alt', alt]);
+    attributes.push({name: 'alt', value: alt});
   }
   return new ElementNode('img', attributes, SELF_CLOSING);
 };


### PR DESCRIPTION
* SyntheticDOM expects attributes to be provided as Object { name, value }

See: https://github.com/sstur/synthetic-dom/blob/master/src/SyntheticDOM.js#L3

This is likely the root cause for: https://github.com/sstur/react-rte/issues/121

* Removed whitespace

* Also fixed attribute format for the code element

Should fix: https://github.com/sstur/react-rte/issues/75